### PR TITLE
Support local mods folder (KSA v2026.2.34.3656)

### DIFF
--- a/KittenExtensions/Patch/Patcher.cs
+++ b/KittenExtensions/Patch/Patcher.cs
@@ -113,6 +113,10 @@ public static partial class XmlPatcher
   private static void LoadModData(ModEntry modEntry)
   {
     var tomlPath = Path.Combine("Content", modEntry.Id, "mod.toml");
+    if (!File.Exists(tomlPath))
+    {
+      tomlPath = Path.Combine(ModLibrary.LocalModsFolderPath, modEntry.Id, "mod.toml");
+    }
     var dirPath = Filepath.CorrectSeparators(Path.GetFullPath(Path.GetDirectoryName(tomlPath) ?? ""));
     ModToml mod;
     try

--- a/README.md
+++ b/README.md
@@ -14,8 +14,10 @@ Current Features:
 ## Installation
 
 - Required [Starmap](https://github.com/StarMapLoader/StarMap)
-- Download zip from [Releases](https://github.com/tsholmes/KittenExtensions/releases/latest) and extract into game `Content` folder
-- Add to `manifest.toml` in `%USER%/my games/Kitten Space Agency`
+- Download zip from [Releases](https://github.com/tsholmes/KittenExtensions/releases/latest) and extract into one of these locations:
+    - `Documents/My Games/Kitten Space Agency/mods/` (recommended, persists across game updates)
+    - Game `Content` folder
+- The game auto-discovers new mods and prompts you to enable them. Alternatively, add to `manifest.toml` in `Documents/My Games/Kitten Space Agency`:
     ```toml
     [[mods]]
     id = "KittenExtensions"
@@ -68,7 +70,7 @@ Patch operations run against the GameData xml document, constructed from xml fil
 
 If you want to inspect the GameData document after patching is done, you can enable the debug flag in your mod manifest:
 ```toml
-# %USER%/my games/Kitten Space Agency/manifest.toml
+# Documents/My Games/Kitten Space Agency/manifest.toml
 
 [[mods]]
 id = "KittenExtensions"


### PR DESCRIPTION
Closes #4

KSA v2026.2.34.3656 introduced a local mods folder at `Documents/My Games/Kitten Space Agency/mods/`. This PR adds support for it.

## Changes

- **Patcher.cs LoadModData()**: Now checks both `Content/` and `ModLibrary.LocalModsFolderPath` when resolving mod paths, matching the game's own fallback pattern
- **README.md**: Updated installation section to document both mod locations, fixed manifest.toml path references

## Tested

- Built and ran against KSA v2026.2.34.3656 via StarMap
- Mod in `Content/`: loads correctly, no errors
- Mod in `Documents/.../mods/`: loads correctly, no `DirectoryNotFoundException`
- same Mod in both locations: loads once from `Content/`, no duplicates